### PR TITLE
feat: Add GAML line in generator to disable pop-up asking to close simulation before reopening another one

### DIFF
--- a/GAMA Plugin/gaml.extension.unity/src/gaml/extension/unity/commands/wizard/VRModelGenerator.java
+++ b/GAMA Plugin/gaml.extension.unity/src/gaml/extension/unity/commands/wizard/VRModelGenerator.java
@@ -463,6 +463,9 @@ public class VRModelGenerator {
 				}
 			}
 
+			// Disable the `ask closing` pop-up for VR experiment only
+			modelUnityLinker.append("\n\t\tgama.pref_experiment_ask_closing <- false;");
+
 			modelUnityLinker.append("\n\t}");
 
 		}


### PR DESCRIPTION
Related to this : https://github.com/project-SIMPLE/simple.webplatform/issues/114#issuecomment-3874886744

I did add it in generated VR experiment since it can be a behavior which is not desired (this is open to debate; if not, I do can add it directly inside all the `experiment .... type: unity` )